### PR TITLE
publish: run on ubuntu-latest instead of html_publisher

### DIFF
--- a/.github/_scopeprobe.txt
+++ b/.github/_scopeprobe.txt
@@ -1,1 +1,0 @@
-scope probe

--- a/.github/_scopeprobe.txt
+++ b/.github/_scopeprobe.txt
@@ -1,0 +1,1 @@
+scope probe

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: html_publisher
+    runs-on: ubuntu-latest
     environment:
       name: ${{ github.ref_name == 'main' && 'github-pages' || 'preview' }}
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Problem

The `publish` workflow (GitHub Pages) has `runs-on: html_publisher`, a self-hosted runner. That runner is currently unavailable, so the most recent dispatch (`27216255300`) sat in `queued` for 2+ days and never executed — it can't even be cancelled (API returns HTTP 500 since no runner ever claimed it).

The earlier red-X failures were a separate, already-fixed issue: `actions/deploy-pages@v4` returned `HttpError: Not Found` because Pages wasn't enabled with **GitHub Actions** as the build source. Pages is now configured with `build_type: workflow`.

## Fix

Switch `runs-on: html_publisher` → `ubuntu-latest`. The job only uses GitHub-hosted actions (checkout, setup-python, pip, jupyter nbconvert, upload-pages-artifact, deploy-pages), so it has no dependency on the self-hosted runner and runs fine on a hosted one. This unblocks the Pages deploy.

## Verification

After merge, `publish.yaml` will run on push to main / workflow_dispatch and should complete the deploy step, publishing to https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/

This pull request and its description were written by Isaac.