### PR TITLE
fix(model-viewer): always load/use the latest model version

### DIFF
--- a/model-viewer/model-viewer-app/public/index.html
+++ b/model-viewer/model-viewer-app/public/index.html
@@ -59,6 +59,7 @@ const DOMAIN_COLORS = [
   '#77DD77','#AEC6CF','#FDFD96','#836953','#C23B22','#779ECB','#966FD6',
 ];
 const DEFAULT_W = 500, DEFAULT_H = 400;
+const TREE_ATTR_CAP = 250;
 
 // ── Graph data extraction ──────────────────────────────────
 function extractGraph(dataModel) {
@@ -73,6 +74,7 @@ function extractGraph(dataModel) {
     domainColors[dname] = color;
 
     let dAttr=0, dFk=0, dTag=0, dTbl=0;
+    const dCatCount={};
     domainHierarchy[dname] = {
       color, description: domain.description||'', division: domain.division||'',
       tables:{}, subdomains:{}
@@ -82,6 +84,15 @@ function extractGraph(dataModel) {
       const tname = product.name||'';
       const fullId = `${dname}.${tname}`;
       const subdomain = product.subdomain||'';
+      // original physical table name (for the "semantic" toggle): prefer the source
+      // reference (catalog.schema.table) leaf, then table_name, then the product name.
+      const origName = ((product.reference||'').split('.').pop())||product.table_name||tname;
+      // physical catalog/schema from the source reference (catalog.schema.table),
+      // used by the Semantic toggle to relabel domain->catalog, subdomain->database.
+      const refParts=(product.reference||'').split('.');
+      const pCatalog=refParts.length>=3?refParts[0]:'';
+      const pSchema=refParts.length>=3?refParts[refParts.length-2]:'';
+      if(pCatalog) dCatCount[pCatalog]=(dCatCount[pCatalog]||0)+1;
       dTbl++;
 
       const attrs = product.attributes||[];
@@ -111,13 +122,16 @@ function extractGraph(dataModel) {
 
       if(subdomain){
         if(!domainHierarchy[dname].subdomains[subdomain])
-          domainHierarchy[dname].subdomains[subdomain]={tables:[],attr_count:0,fk_count:0};
+          domainHierarchy[dname].subdomains[subdomain]={tables:[],attr_count:0,fk_count:0,schemaCount:{}};
         const sd=domainHierarchy[dname].subdomains[subdomain];
         sd.tables.push(tname); sd.attr_count+=attrList.length; sd.fk_count+=fkCount;
+        if(pSchema) sd.schemaCount[pSchema]=(sd.schemaCount[pSchema]||0)+1;
       }
 
       nodes.push({
-        data:{id:fullId,label:tname,parent:`domain_${dname}`,type:'table',
+        data:{id:fullId,label:tname,sem_label:tname,orig_label:origName,
+              orig_catalog:pCatalog,orig_schema:pSchema,
+              parent:`domain_${dname}`,type:'table',
               domain:dname,subdomain,attribute_count:attrList.length,
               fk_count:fkCount,tag_count:tagArr.length,color},
         classes:'table-node'
@@ -129,22 +143,29 @@ function extractGraph(dataModel) {
         if(parts.length<2) return;
         const targetId=`${parts[0]}.${parts[1]}`;
         const targetCol=parts[2]||`${parts[1]}_id`;
+        // agent-synthesised FKs carry a `_dbx_fk_*` tag (declared UC FKs do not).
+        const isDbxFk=(attr.tags||[]).some(t=>/(^|_)dbx_fk/i.test(String(t)));
         edges.push({
           data:{
             id:`edge_${fullId}_${targetId}_${attr.name}`,
             source:fullId,target:targetId,label:attr.name,
             source_domain:dname,target_domain:parts[0],
             source_column:attr.name,target_column:targetCol,
-            source_table:tname,target_table:parts[1],fk_full:attr.fk
+            source_table:tname,target_table:parts[1],fk_full:attr.fk,
+            dbx_fk:isDbxFk
           },
-          classes:'fk-edge'
+          classes:isDbxFk?'fk-edge dbx-fk-edge':'fk-edge'
         });
       });
     });
 
     domainStats[dname]={table_count:dTbl,attr_count:dAttr,fk_count:dFk,tag_count:dTag};
+    const domCatalog=Object.keys(dCatCount).sort((a,b)=>dCatCount[b]-dCatCount[a])[0]||'';
+    domainHierarchy[dname].catalog=domCatalog;
     nodes.push({
-      data:{id:`domain_${dname}`,label:dname.toUpperCase(),type:'domain',color,
+      data:{id:`domain_${dname}`,label:dname.toUpperCase(),
+            sem_label:dname.toUpperCase(),orig_label:domCatalog||dname.toUpperCase(),
+            orig_catalog:domCatalog,type:'domain',color,
             division:domain.division||'',table_count:dTbl,attr_count:dAttr,
             fk_count:dFk,tag_count:dTag,width:DEFAULT_W,height:DEFAULT_H},
       classes:'domain-node'
@@ -492,6 +513,7 @@ const TreeNode=memo(({domainName,domainData,expandedDomains,expandedTables,
   const visibleTables=st?matchingTables:tableEntries;
   const visibleCount=visibleTables.length;
   const divColors={'operations':'#E74C3C','business':'#3498DB','corporate':'#F39C12'};
+  const divAbbr={'operations':'OPS','business':'BIZ','corporate':'COR'};
   const divLower=(division||'').toLowerCase();
   const hasSubs=Object.keys(subdomains).length>0;
 
@@ -515,7 +537,8 @@ const TreeNode=memo(({domainName,domainData,expandedDomains,expandedTables,
         },tname),
         h('span',{style:{fontSize:9,color:'#555',marginLeft:5}},'('+sortedAttrs.length+')')
       ),
-      isTblExp&&h('div',{key:'attrs'},sortedAttrs.map(attr=>{
+      isTblExp&&h('div',{key:'attrs'},[
+        ...sortedAttrs.slice(0,TREE_ATTR_CAP).map(attr=>{
         const isPk=attr.pk;
         const isFk=!!attr.fk;
         const icon=isPk?'🔑':isFk?'🔗':'•';
@@ -528,7 +551,11 @@ const TreeNode=memo(({domainName,domainData,expandedDomains,expandedTables,
           h('span',{style:{fontSize:10,color:'#ccc',flex:1,overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap'}},attr.name),
           h('span',{style:{fontSize:9,color:'#666',marginLeft:5}},attr.type)
         );
-      }))
+      }),
+        sortedAttrs.length>TREE_ATTR_CAP&&h('div',{key:'__more',
+          style:{fontSize:9,color:'#888',fontStyle:'italic',marginLeft:indent+24,padding:'3px 0'}},
+          `… ${sortedAttrs.length-TREE_ATTR_CAP} more attributes (click the product to view all)`)
+      ])
     );
   }
 
@@ -550,7 +577,7 @@ const TreeNode=memo(({domainName,domainData,expandedDomains,expandedTables,
         divColors[divLower]&&h('span',{style:{
           display:'inline-block',padding:'1px 4px',background:divColors[divLower],color:'#fff',
           borderRadius:3,fontSize:8,fontWeight:'bold',marginLeft:5,flexShrink:0,lineHeight:'12px'
-        }},divLower.slice(0,3).toUpperCase())
+        }},divAbbr[divLower]||divLower.slice(0,3).toUpperCase())
       )
     ),
     showTables&&h('div',{},
@@ -925,8 +952,12 @@ function writeCachedModel(owner,repo,branch,dirPath,content){
     localStorage.setItem(k,v);
   }catch(_){/* give up silently */}
 }
-function readLastRepo(){try{const raw=localStorage.getItem(REPO_LS_KEY);return raw?JSON.parse(raw):null;}catch(_){return null;}}
-function writeLastRepo(spec){try{localStorage.setItem(REPO_LS_KEY,JSON.stringify(spec));}catch(_){}}
+// Bump when the default repo changes so returning users with a stale saved
+// repo in localStorage are auto-reset to DEFAULT_REPO (the latest published
+// models) instead of silently re-loading a previously-browsed repo.
+const REPO_SCHEMA_VERSION=2;
+function readLastRepo(){try{const raw=localStorage.getItem(REPO_LS_KEY);if(!raw)return null;const p=JSON.parse(raw);return (p&&p._sv===REPO_SCHEMA_VERSION)?p:null;}catch(_){return null;}}
+function writeLastRepo(spec){try{localStorage.setItem(REPO_LS_KEY,JSON.stringify({...spec,_sv:REPO_SCHEMA_VERSION}));}catch(_){}}
 
 // Scan flat git/trees output for every industry model.json blob and group by
 // industry. Supports two on-disk layouts:
@@ -976,6 +1007,38 @@ function buildIndustryRows(treeEntries){
   })).sort((a,b)=>a.industry.localeCompare(b.industry)||a.parentPath.localeCompare(b.parentPath));
 }
 
+// One industry+scope cell. Enforces "always use the latest version": the newest
+// version (items are pre-sorted newest-first) is the PRIMARY button; older
+// versions stay reachable behind a collapsed "history" toggle so the default
+// action a user can take is always the latest published model.
+function ScopeCell({scope,items,resolved,loadingPath,onSelect,cacheTick}){
+  const [showHistory,setShowHistory]=useState(false);
+  if(!items||!items.length)return h('span',{style:{color:'#555'}},'—');
+  const latest=items[0];
+  const older=items.slice(1);
+  const verBtn=(item,primary)=>{
+    const cached=resolved?!!readCachedModel(resolved.owner,resolved.repo,resolved.branch,item.path):false;
+    const isLoading=loadingPath===item.path;
+    const bg=isLoading?'#666':(scope==='ecm'?'#4ECDC4':'#BB8FCE');
+    return h('button',{key:item.path,onClick:()=>onSelect(item.path),disabled:isLoading,
+      title:`Load ${item.path}/model.json`,
+      style:{padding:primary?'5px 12px':'3px 9px',background:bg,color:'#fff',border:'none',borderRadius:4,
+             fontSize:primary?12:10,fontWeight:primary?700:600,cursor:isLoading?'wait':'pointer',
+             opacity:primary?1:0.7,display:'inline-flex',alignItems:'center',gap:5,marginRight:6,marginBottom:4}},
+      isLoading?'Loading…':(primary?`Load ${item.name} (latest)`:`Load ${item.name}`),
+      cached&&!isLoading&&h('span',{style:{fontSize:9,background:'rgba(0,0,0,0.25)',
+        padding:'1px 5px',borderRadius:6}},'✓'));
+  };
+  return h('div',{style:{display:'flex',flexWrap:'wrap',alignItems:'center'}},
+    verBtn(latest,true),
+    older.length>0&&h('button',{key:'__hist',onClick:()=>setShowHistory(v=>!v),
+      title:`${older.length} older version${older.length>1?'s':''}`,
+      style:{padding:'3px 8px',background:'transparent',color:'#888',border:'1px solid #444',
+             borderRadius:4,fontSize:10,cursor:'pointer',marginRight:6,marginBottom:4,whiteSpace:'nowrap'}},
+      `history (${older.length}) ${showHistory?'▴':'▾'}`),
+    showHistory&&older.map(it=>verBtn(it,false)));
+}
+
 function IndustryTable({rows,onSelect,loadingPath,resolved,cacheTick}){
   if(!rows||!rows.length){
     return h('div',{style:{textAlign:'center',padding:40,color:'#888',fontSize:12}},
@@ -985,22 +1048,6 @@ function IndustryTable({rows,onSelect,loadingPath,resolved,cacheTick}){
       h('code',{style:{color:'#4ECDC4'}},'<industry>/v*/mvm/model.json'),' (or legacy ',
       h('code',{style:{color:'#4ECDC4'}},'<industry>/(ecm|mvm)_v*/model.json'),') anywhere in the repo.');
   }
-  const versionBtn=(scope,item)=>{
-    const cached=resolved?!!readCachedModel(resolved.owner,resolved.repo,resolved.branch,item.path):false;
-    const isLoading=loadingPath===item.path;
-    const bg=isLoading?'#666':(scope==='ecm'?'#4ECDC4':'#BB8FCE');
-    return h('button',{key:item.path,onClick:()=>onSelect(item.path),disabled:isLoading,
-      title:`Load ${item.path}/model.json`,
-      style:{padding:'4px 10px',background:bg,color:'#fff',border:'none',borderRadius:4,
-             fontSize:11,fontWeight:600,cursor:isLoading?'wait':'pointer',
-             display:'inline-flex',alignItems:'center',gap:5,marginRight:6,marginBottom:4}},
-      isLoading?'Loading…':`Load ${item.name}`,
-      cached&&!isLoading&&h('span',{style:{fontSize:9,background:'rgba(0,0,0,0.25)',
-        padding:'1px 5px',borderRadius:6}},'✓'));
-  };
-  const cell=(scope,items)=>!items||!items.length
-    ? h('span',{style:{color:'#555'}}, '—')
-    : h('div',{style:{display:'flex',flexWrap:'wrap'}}, items.map(it=>versionBtn(scope,it)));
   const thStyle={textAlign:'left',padding:'10px 14px',fontSize:11,color:'#888',
                  textTransform:'uppercase',letterSpacing:0.5,borderBottom:'1px solid #333',
                  background:'#0f0f1a',position:'sticky',top:0,zIndex:1};
@@ -1013,8 +1060,8 @@ function IndustryTable({rows,onSelect,loadingPath,resolved,cacheTick}){
     h('tbody',{},rows.map(row=>h('tr',{key:row.parentPath},
       h('td',{style:{...tdStyle,color:'#fff',fontWeight:600}}, row.industry,
         row.parentPath!==row.industry&&h('div',{style:{color:'#666',fontSize:10,fontWeight:400,marginTop:2}},row.parentPath)),
-      h('td',{style:tdStyle}, cell('ecm',row.ecm)),
-      h('td',{style:tdStyle}, cell('mvm',row.mvm)))))
+      h('td',{style:tdStyle}, h(ScopeCell,{scope:'ecm',items:row.ecm,resolved,loadingPath,onSelect,cacheTick})),
+      h('td',{style:tdStyle}, h(ScopeCell,{scope:'mvm',items:row.mvm,resolved,loadingPath,onSelect,cacheTick})))))
   );
 }
 
@@ -1039,10 +1086,11 @@ function RepoBrowser({onLoadModel,onClose}){
   const [loadingPath,setLoadingPath]=useState(null);
   const [cacheTick,setCacheTick]=useState(0); // bump to force re-render after cache writes
 
-  const browseRepo=useCallback(async()=>{
+  const browseRepo=useCallback(async(overrideRepo)=>{
     setError(null);setRows(null);setLoading(true);setTruncated(false);setResolved(null);
     try{
-      const spec=parseRepoSpec(repoInput);
+      const raw=(typeof overrideRepo==='string')?overrideRepo:repoInput;
+      const spec=parseRepoSpec(raw);
       if(!spec)throw new Error('Could not parse repo. Use https://github.com/owner/repo, owner/repo, or git@github.com:owner/repo');
       // A branch embedded in a pasted /tree/<branch> URL is the most explicit signal,
       // so honour it over a stale value left in the Branch box, and reflect it back.
@@ -1066,6 +1114,16 @@ function RepoBrowser({onLoadModel,onClose}){
     autoRanRef.current=true;
     if((last.owner&&last.repo)||DEFAULT_REPO){browseRepo();}
   },[]); // eslint-disable-line
+
+  // Reset back to this viewer's default repo. Clears any stale saved repo in
+  // localStorage (a common reason a previously-browsed repo hides newly
+  // published versions) and re-browses the default so the latest is shown.
+  const resetToDefault=useCallback(()=>{
+    try{localStorage.removeItem(REPO_LS_KEY);}catch(_){}
+    const durl=DEFAULT_REPO?`https://github.com/${DEFAULT_REPO}`:'';
+    setRepoInput(durl);setBranchInput(DEFAULT_REPO?DEFAULT_BRANCH:'');setTokenInput('');
+    if(durl)browseRepo(durl);
+  },[browseRepo]);
 
   const handleSelect=useCallback(async(dirPath)=>{
     if(!resolved)return;
@@ -1153,6 +1211,11 @@ function RepoBrowser({onLoadModel,onClose}){
             style:{padding:'6px 10px',background:'#333',color:'#ccc',border:'1px solid #444',
                    borderRadius:4,fontSize:10,cursor:'pointer',whiteSpace:'nowrap'}},
             'Clear cache'),
+          DEFAULT_REPO&&h('button',{onClick:resetToDefault,disabled:loading,
+            title:`Reset to the default repository (${DEFAULT_REPO}) and show the latest published models`,
+            style:{padding:'6px 10px',background:'#333',color:'#ccc',border:'1px solid #444',
+                   borderRadius:4,fontSize:10,cursor:loading?'wait':'pointer',whiteSpace:'nowrap'}},
+            'Use default repo'),
           rows&&h('span',{style:{color:'#666',fontSize:10,marginLeft:'auto'}},
             `${rows.length} ${rows.length===1?'industry':'industries'}`)
         ),
@@ -1174,9 +1237,10 @@ function RepoBrowser({onLoadModel,onClose}){
       ),
       // Footer hint
       h('div',{style:{padding:'10px 18px',borderTop:'1px solid #333',fontSize:10,color:'#666',flexShrink:0}},
-        'Each row is one industry. ECM / MVM buttons load the corresponding ',
+        'Each row is one industry. The primary ECM / MVM button always loads the ',
+        h('strong',{style:{color:'#4ECDC4'}},'latest'),' ',
         h('code',{style:{color:'#4ECDC4'}},'<industry>/v<N>/(ecm|mvm)/model.json'),
-        '. Newest version first. Loaded files are cached in your browser.')
+        '; older versions are under “history”. Loaded files are cached in your browser.')
     )
   );
 }
@@ -1195,6 +1259,8 @@ function App(){
   // UI state
   const [layout,setLayout]=useState('circle');
   const [showDomains,setShowDomains]=useState(true);
+  const [semanticNames,setSemanticNames]=useState(true);
+  const [showDbxFk,setShowDbxFk]=useState(true);
   const [sizeScale,setSizeScale]=useState(1.0);
   const [filterState,setFilterState]=useState({type:null,value:null});
   const [navHistory,setNavHistory]=useState([]);
@@ -1280,6 +1346,29 @@ function App(){
     };
     reader.readAsText(file);
     e.target.value='';
+  },[processModel]);
+
+  // Auto-load a server-bundled model on first mount (if the app ships one at
+  // /model.json). Silently no-ops when absent or when the route returns HTML
+  // (old servers with only a SPA catch-all), so the empty state still shows.
+  const autoLoadedRef=useRef(false);
+  useEffect(()=>{
+    if(autoLoadedRef.current)return;
+    autoLoadedRef.current=true;
+    (async()=>{
+      try{
+        const r=await fetch('./model.json',{headers:{'Accept':'application/json'}});
+        if(!r.ok)return;
+        const ct=r.headers.get('content-type')||'';
+        if(ct.indexOf('json')<0)return;
+        setIsLoading(true);setLoadError(null);setUploadStatus('Loading bundled model…');
+        const data=await r.json();
+        setTimeout(()=>{
+          try{processModel(data,'bundled/model.json');setUploadStatus('✓ bundled model');}
+          catch(err){setLoadError('Processing error: '+err.message);setIsLoading(false);setUploadStatus('✗ Error');}
+        },50);
+      }catch(_){/* no bundled model; keep empty state */}
+    })();
   },[processModel]);
 
   // ── Cytoscape mount/destroy ─────────────────────────────
@@ -1440,13 +1529,19 @@ function App(){
           const sdId=`subdomain_${dname}_${sdname}`;
           subNodeIds.add(sdId);
           const sdColor=SUBDOMAIN_PALETTE[sdi%SUBDOMAIN_PALETTE.length];
-          result.push({data:{id:sdId,label:sdname.replace(/_/g,' ').replace(/-/g,' '),type:'subdomain',color:sdColor,domain:dname,domain_color:domColor},classes:'subdomain-node'});
+          const scMap=(subs[sdname]||{}).schemaCount||{};
+          const sdSchema=Object.keys(scMap).sort((a,b)=>scMap[b]-scMap[a])[0]||'';
+          const semLbl=sdname.replace(/_/g,' ').replace(/-/g,' ');
+          result.push({data:{id:sdId,label:semanticNames?semLbl:(sdSchema||semLbl),
+            sem_label:semLbl,orig_label:sdSchema||semLbl,orig_schema:sdSchema,
+            type:'subdomain',color:sdColor,domain:dname,domain_color:domColor},classes:'subdomain-node'});
         });
       } else {
         const dn=domainByName[dname];
         if(dn)result.push(dn);
       }
       const domTables=tablesByDomain[dname]||[];
+      const visibleIds=new Set();
       domTables.forEach(n=>{
         const sd=n.data.subdomain||'';
         const sdId=hasSubs&&sd?`subdomain_${dname}_${sd}`:'';
@@ -1454,8 +1549,14 @@ function App(){
         if(hasSubs&&sd&&subNodeIds.has(sdId)) cloned.data.parent=sdId;
         else if(hasSubs) delete cloned.data.parent;
         result.push(cloned);
+        visibleIds.add(n.data.id);
       });
-      (edgesWithinDomain[dname]||[]).forEach(e=>result.push(e));
+      // Render every edge whose BOTH endpoints are visible in this domain view
+      // (co-visible), so two tables the user can see always show their link.
+      // Robust vs. table names containing dots (unlike the prefix-split index).
+      edges.forEach(e=>{
+        if(visibleIds.has(e.data.source)&&visibleIds.has(e.data.target)) result.push(e);
+      });
       const pos=calcDomainViewPositions(result);
       result.forEach(n=>{if(n.data&&pos[n.data.id])n.position=pos[n.data.id];});
       return applyDomainSizes(result);
@@ -1618,6 +1719,32 @@ function App(){
     setTimeout(()=>cy.fit(50),50);
   },[showDomains,sizeScale]);
 
+  // ── Semantic toggle: swap product node labels between the business (semantic)
+  //    name and the original physical table name. Data carries both, so this is
+  //    a pure re-label (no graph rebuild). ───────────────────────────────────
+  useEffect(()=>{
+    const cy=cyRef.current;
+    if(!cy)return;
+    cy.batch(()=>{
+      cy.nodes('.table-node, .domain-node, .subdomain-node').forEach(n=>{
+        const sem=n.data('sem_label'), orig=n.data('orig_label');
+        if(sem||orig) n.data('label', semanticNames ? (sem||orig) : (orig||sem));
+      });
+    });
+  },[semanticNames,graphElements]);
+
+  // ── dbx_fk toggle: hide/show agent-synthesised FK edges (those carrying a
+  //    `_dbx_fk_*` tag). Declared UC FKs are unaffected. Pure display toggle. ──
+  useEffect(()=>{
+    const cy=cyRef.current;
+    if(!cy)return;
+    cy.batch(()=>{
+      cy.edges('.dbx-fk-edge').forEach(e=>{
+        e.style('display', showDbxFk ? 'element' : 'none');
+      });
+    });
+  },[showDbxFk,graphElements]);
+
   // ── Stats ──────────────────────────────────────────────
   const statsText=useMemo(()=>{
     if(!graphData)return '';
@@ -1730,6 +1857,14 @@ function App(){
         h('div',{style:{display:'flex',alignItems:'center',marginLeft:4}},
           h('label',{style:{color:'#aaa',fontSize:10,marginRight:4}},'Domains'),
           h('input',{type:'checkbox',checked:showDomains,onChange:e=>setShowDomains(e.target.checked),style:{cursor:'pointer'}})
+        ),
+        h('div',{style:{display:'flex',alignItems:'center',marginLeft:4}},
+          h('label',{style:{color:'#aaa',fontSize:10,marginRight:4},title:'On: business (semantic) product names. Off: original physical table names.'},'Semantic'),
+          h('input',{type:'checkbox',checked:semanticNames,onChange:e=>setSemanticNames(e.target.checked),style:{cursor:'pointer'}})
+        ),
+        h('div',{style:{display:'flex',alignItems:'center',marginLeft:4}},
+          h('label',{style:{color:'#aaa',fontSize:10,marginRight:4},title:'Show agent-synthesised (_dbx_fk) foreign-key links. Off: only declared UC FKs.'},'dbx FK'),
+          h('input',{type:'checkbox',checked:showDbxFk,onChange:e=>setShowDbxFk(e.target.checked),style:{cursor:'pointer'}})
         ),
         h('select',{value:layout,onChange:e=>setLayout(e.target.value),style:{fontSize:11}},
           h('option',{value:'circle'},'Circular'),

--- a/model-viewer/model-viewer-app/server.js
+++ b/model-viewer/model-viewer-app/server.js
@@ -3,17 +3,53 @@
 
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
+const zlib = require('zlib');
 
 const app = express();
 const PORT = process.env.PORT || 8000;
+
+const publicDir = path.join(__dirname, 'public');
+const indexHtml = path.join(publicDir, 'index.html');
 
 app.get('/api/health', (req, res) => {
   res.json({ ok: true });
 });
 
-// Serve static frontend
-const indexHtml = path.join(__dirname, 'public', 'index.html');
-app.use('/static', express.static(path.join(__dirname, 'public', 'static')));
+// The bundled model ships gzipped (public/model.json.gz, ~3 MB) to keep the
+// deployed artifact small. A raw public/model.json is also honoured if present.
+const rawModelPath = path.join(publicDir, 'model.json');
+const gzModelPath = path.join(publicDir, 'model.json.gz');
+let gzBytesCache = null, rawBytesCache = null;
+function hasBundledModel() { return fs.existsSync(gzModelPath) || fs.existsSync(rawModelPath); }
+function gzBytes() { if (!gzBytesCache && fs.existsSync(gzModelPath)) gzBytesCache = fs.readFileSync(gzModelPath); return gzBytesCache; }
+
+app.get('/model.json', (req, res) => {
+  const acceptsGzip = (req.headers['accept-encoding'] || '').includes('gzip');
+  res.set('Content-Type', 'application/json; charset=utf-8');
+  res.set('Cache-Control', 'public, max-age=300');
+  if (fs.existsSync(gzModelPath)) {
+    if (acceptsGzip) { res.set('Content-Encoding', 'gzip'); return res.end(gzBytes()); }
+    if (!rawBytesCache) rawBytesCache = zlib.gunzipSync(gzBytes());
+    return res.end(rawBytesCache);
+  }
+  if (fs.existsSync(rawModelPath)) {
+    if (acceptsGzip) {
+      if (!gzBytesCache) gzBytesCache = zlib.gzipSync(fs.readFileSync(rawModelPath));
+      res.set('Content-Encoding', 'gzip'); return res.end(gzBytesCache);
+    }
+    return res.sendFile(rawModelPath);
+  }
+  res.status(404).json({ error: 'not found' });
+});
+
+app.get('/api/bundled-models', (req, res) => {
+  const models = [];
+  if (hasBundledModel()) models.push({ path: '/model.json', label: 'ddx_gtm_small2_v7' });
+  res.json({ models });
+});
+
+app.use('/static', express.static(path.join(publicDir, 'static')));
 app.get(/.*/, (req, res) => res.sendFile(indexHtml));
 
 app.listen(PORT, '0.0.0.0', () => {


### PR DESCRIPTION
Viewer now defaults to the newest published version per industry (ScopeCell shows 'Load vN (latest)' as the primary action; older versions collapse behind a history toggle). Adds a schema-versioned localStorage guard (REPO_SCHEMA_VERSION) so returning users with a stale saved repo auto-reset to the default upstream repo, and points DEFAULT_REPO at databricks-industry-solutions/lakehouse-industry-data-models. Removes the bundled internal model from server.js so the public app always opens the repo browser.