### PR TITLE
Point gallery README and manifest at canonical upstream repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
           python3 -u tools/build_manifest.py \
             --repo . \
             --ref "$GITHUB_SHA" \
-            --source "$GITHUB_REPOSITORY" \
+            --source databricks-industry-solutions/lakehouse-industry-data-models \
             --strict \
             --out docs/manifest.json
           python3 -m json.tool docs/manifest.json > /dev/null

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forty production-ready industry data models, each shipped in two flavours (ECM +
 
 **40 industries · 80 models · 23,918 tables · 924,919 attributes · 167,214 foreign keys · 10,488 metric views**
 
-**[Open the interactive gallery](https://amralieg.github.io/lakehouse-industry-data-models-fix/)** · **[View the repository on GitHub](https://github.com/databricks-industry-solutions/lakehouse-industry-data-models)**
+**[Open the interactive gallery](https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/)**
 
 ![Lakehouse Industry Data Model gallery — interactive ER graph viewer](./docs/gallery-screenshot.png)
 

--- a/tools/build_manifest.py
+++ b/tools/build_manifest.py
@@ -48,6 +48,8 @@ EXPECTED_SECTIONS = 8
 EXPECTED_INDUSTRIES = 40
 EXPECTED_MODELS = 108
 
+CANONICAL_SOURCE_SLUG = "databricks-industry-solutions/lakehouse-industry-data-models"
+
 # The version models-info.csv describes. Its rows carry no version column, and
 # every row matches the v1 model.json exactly, so this is the safe reading.
 CSV_VERSION = "v1"
@@ -341,10 +343,9 @@ def version_sort_key(version: str) -> int:
 
 
 def resolve_source(repo: Path, ref: str, override: str | None) -> dict:
-    """Owner/repo for the CDN URLs. An explicit override wins, then
-    GITHUB_REPOSITORY so a fork or an upstream merge needs no edit, then the git
-    remote. The remote is last because it goes stale when a repo is renamed."""
-    slug = (override or os.environ.get("GITHUB_REPOSITORY", "")).strip()
+    """Owner/repo recorded in the manifest. Defaults to the canonical upstream
+    project so fork Pages builds never advertise the fork as the model source."""
+    slug = (override or CANONICAL_SOURCE_SLUG).strip()
     if not slug:
         url = run_git(repo, "remote", "get-url", "origin").strip()
         match = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?$", url)
@@ -550,7 +551,7 @@ def main() -> int:
     parser.add_argument(
         "--source",
         default=None,
-        help="owner/repo the page fetches models from (default: $GITHUB_REPOSITORY, then origin)",
+        help=f"owner/repo recorded in manifest.source (default: {CANONICAL_SOURCE_SLUG})",
     )
     parser.add_argument(
         "--strict",


### PR DESCRIPTION
## Summary

Follow-up to #24: every public link in the README and CI-built manifest now targets the official `databricks-industry-solutions/lakehouse-industry-data-models` repo, not a contributor fork.

## Changes

- **README** — gallery link uses `https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/`; removed the redundant separate "View the repository on GitHub" link (the repo is already where the README lives).
- **Pages CI** — `build_manifest.py` is invoked with `--source databricks-industry-solutions/lakehouse-industry-data-models` so `manifest.source` never records a fork slug when CI runs on a fork.
- **`tools/build_manifest.py`** — default `manifest.source` slug is the same canonical upstream constant.

The gallery app (`docs/index.html`) already fetched models and linked GitHub chrome to upstream; this PR aligns README + manifest metadata with that behaviour.

## Test plan

- [x] `python3 tools/build_manifest.py --strict --out /tmp/manifest.json` → `source.owner/repo` = `databricks-industry-solutions/lakehouse-industry-data-models`
- [x] `python3 tools/build_manifest.py --check /tmp/manifest.json` passes
- [ ] After merge: confirm README gallery link resolves once Pages is enabled on this repo