### PR TITLE
Fix README gallery link (upstream Pages not enabled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forty production-ready industry data models, each shipped in two flavours (ECM +
 
 **40 industries · 80 models · 23,092 tables · 885,842 attributes · 156,641 foreign keys · 11,661 metric views**
 
-**[Open the interactive gallery](https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/)**
+**[Open the interactive gallery](https://amralieg.github.io/lakehouse-industry-data-models-fix/)**
 
 ![Lakehouse Industry Data Model gallery — interactive ER graph viewer](./docs/gallery-screenshot.png)
 


### PR DESCRIPTION
## Summary

PR #25 pointed the README gallery link at `https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/`, which **404s** because GitHub Pages is not enabled on this upstream repository yet (the Pages API returns `Not Found`).

The gallery is live today on the preview deployment:

https://amralieg.github.io/lakehouse-industry-data-models-fix/

That deployment already loads every `model.json` from **this** repo on `main` and all in-app GitHub chrome links point here too.

## Change

- README gallery link → the working preview URL above.

## Follow-up for maintainers

After enabling **GitHub Pages → Build and deployment → GitHub Actions** on `databricks-industry-solutions/lakehouse-industry-data-models`, the README link can switch to:

`https://databricks-industry-solutions.github.io/lakehouse-industry-data-models/`

The `.github/workflows/pages.yml` workflow from #24 is already in `main` and will publish on the next push once Pages is enabled.